### PR TITLE
allow user to modify model prediction results

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: A general test for conditional independence in supervised learning
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.2
 URL: https://github.com/bips-hb/cpi,
     https://bips-hb.github.io/cpi/
 BugReports: https://github.com/bips-hb/cpi/issues

--- a/R/compute_loss.R
+++ b/R/compute_loss.R
@@ -1,6 +1,6 @@
 
 # Internal function to compute sample loss
-compute_loss <- function(pred, measure) {
+compute_loss <- function(pred, measure, modify_trp, ...) {
   if (inherits(pred, "Prediction")) {
     truth <- pred$truth
     response <- pred$response
@@ -9,6 +9,13 @@ compute_loss <- function(pred, measure) {
     truth <- do.call(c, lapply(pred, function(x) x$truth))
     response <- do.call(c, lapply(pred, function(x) x$response))
     prob <- do.call(rbind, lapply(pred, function(x) x$prob))
+  }
+  
+  if (is.function(modify_trp)) {
+    out <- modify_trp(truth, response, prob, ...)
+    truth <- out$truth
+    response <- out$response
+    prob <- out$prob
   }
   
   if (measure$id == "regr.mse") {

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -32,8 +32,19 @@
 #' @param groups (Named) list with groups. Set to \code{NULL} (default) for no
 #'   groups, i.e. compute CPI for each feature. See examples. 
 #' @param verbose Verbose output of resampling procedure.
-#' @param modify_trp An optional function to modify the \code{truth}, \code{response}, and \code{prob} values of the model output. Function must take as arguments the original \code{truth}, \code{response}, and \code{prob} output from model predictions and return a named list of \code{truth}, \code{response}, and \code{prob} values, some of which may be modified. For modified values to work nicely with the rest of the package, they must match the expected format of unmodified values (e.g., \code{prob} must be a data.frame with the number of columns being the number of classes and column names being the class labels; the first level of the \code{truth} factor must be the positive class). See examples. Set to \code{FALSE} (default) to use unmodified truth, response, and probability values from model output.
-#' @param ... Optional arguments to be passed to the \code{modify_trp} function (e.g., a classification threshold).
+#' @param modify_trp An optional function to modify the \code{truth}, \code{response}, 
+#'   and \code{prob} values of the model output. Function must take as arguments the 
+#'   original \code{truth}, \code{response}, and \code{prob} output from model 
+#'   predictions and return a named list of \code{truth}, \code{response}, and 
+#'   \code{prob} values, some of which may be modified. For modified values to work 
+#'   nicely with the rest of the package, they must match the expected format of 
+#'   unmodified values (e.g., \code{prob} must be a data.frame with the number of columns
+#'   being the number of classes and column names being the class labels; the first 
+#'   level of the \code{truth} factor must be the positive class). See examples. Set to 
+#'   \code{FALSE} (default) to use unmodified truth, response, and probability values 
+#'   from model output.
+#' @param ... Optional arguments to be passed to the \code{modify_trp} function 
+#'   (e.g., a classification threshold).
 #'
 #' @return 
 #' For \code{test = "bayes"} a list of \code{BEST} objects. In any other 
@@ -144,10 +155,11 @@
 #' # Data prep:
 #' data <- palmerpenguins::penguins
 #' data$species <- ifelse(data$species == "Adelie", 1, 0)
-#' data <- data[, c("species", "bill_length_mm", "bill_depth_mm", "flipper_length_mm", "body_mass_g")]
+#' keep_cols <- c("species", "bill_length_mm", "bill_depth_mm", 
+#'                "flipper_length_mm", "body_mass_g")
+#' data <- data[, keep_cols]
 #' data <- data[complete.cases(data), ]
-#' task <- TaskRegr$new(id = "penguins.regr", data, target = "species")
-
+#' 
 #' response_is_prob <- function(truth, response, prob) {
 #'    prob <- setNames(data.frame(response, 1 - response), nm = c("1", "0"))
 #'    response <- ifelse(response >= 0.5, yes = 1, no = 0)
@@ -155,7 +167,7 @@
 #'    return(list(truth = truth, response = response, prob = prob))
 #'   }     
 #' 
-#' cpi(task = task, 
+#' cpi(task = TaskRegr$new(id = "penguins.regr", backend = data, target = "species"), 
 #'     learner = lrn("regr.ranger"), 
 #'      resampling = rsmp("holdout"), 
 #'      measure = "classif.logloss", test = "t", 
@@ -165,14 +177,15 @@
 #' # modify_trp function that makes a new classification threshold
 #' # Same data can be used.
 #'  
-#' response_is_prob_new_thresh <- function(truth, response, prob, classification_thresh) {
+#' response_is_prob_new_thresh <- 
+#'   function(truth, response, prob, classification_thresh) {
 #'     prob <- setNames(data.frame(response, 1 - response), nm = c("1", "0"))
 #'     response <- ifelse(response >= classification_thresh, yes = 1, no = 0)
 #'     
 #'     return(list(truth = truth, response = response, prob = prob))
-#' }
+#'   }
 #'    
-#' cpi(task = task, 
+#' cpi(task = TaskRegr$new(id = "penguins.regr", backend = data, target = "species"), 
 #'     learner = lrn("regr.ranger"), 
 #'     resampling = rsmp("holdout"), 
 #'     measure = "classif.logloss", test = "t", 
@@ -190,7 +203,8 @@
 #'     }
 #' 
 #'    classes <- levels(truth)
-#'    response <- ifelse(prob[, classes[1]] >= classification_thresh, yes = classes[1], no = classes[2])
+#'    response <- ifelse(prob[, classes[1]] >= classification_thresh, 
+#'                       yes = classes[1], no = classes[2])
 #'    prob[, classes[1]] <- ifelse(prob[, classes[1]] <= classification_thresh,
 #'                                 yes = rescale(x = prob[, classes[1]],
 #'                                               old_max = classification_thresh,
@@ -211,10 +225,12 @@
 #'  # Data prep
 #'  data = palmerpenguins::penguins
 #'  data$species = factor(ifelse(data$species == "Adelie", "1", "0"))
-#'  data <- data[, c("species", "bill_length_mm", "bill_depth_mm", "flipper_length_mm", "body_mass_g")]
+#'  keep_cols <- c("species", "bill_length_mm", "bill_depth_mm", 
+#'                 "flipper_length_mm", "body_mass_g")
+#'  data <- data[, keep_cols]
 #'  data <- data[complete.cases(data), ]
-
-#'  cpi(task = TaskClassif$new("penguins.binary", data, target = "species", positive = "1"), 
+#'  cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
+#'                             target = "species", positive = "1"), 
 #'      learner = lrn("classif.ranger", predict_type = "prob"), 
 #'      resampling = rsmp("holdout"), 
 #'      measure = "classif.logloss", test = "t", 

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -229,6 +229,7 @@
 #'                 "flipper_length_mm", "body_mass_g")
 #'  data <- data[, keep_cols]
 #'  data <- data[complete.cases(data), ]
+#'  
 #'  cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
 #'                             target = "species", positive = "1"), 
 #'      learner = lrn("classif.ranger", predict_type = "prob"), 
@@ -236,7 +237,8 @@
 #'      measure = "classif.logloss", test = "t", 
 #'      modify_trp = rescale_prob,
 #'      classification_thresh = 0.3)
-#'}
+#' }
+#'
 
 
 cpi <- function(task, learner, 

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -32,6 +32,8 @@
 #' @param groups (Named) list with groups. Set to \code{NULL} (default) for no
 #'   groups, i.e. compute CPI for each feature. See examples. 
 #' @param verbose Verbose output of resampling procedure.
+#' @param modify_trp An optional function to modify the \code{truth}, \code{response}, and \code{prob} values of the model output. Function must take as arguments the original \code{truth}, \code{response}, and \code{prob} output from model predictions and return a named list of \code{truth}, \code{response}, and \code{prob} values, some of which may be modified. For modified values to work nicely with the rest of the package, they must match the expected format of unmodified values (e.g., \code{prob} must be a data.frame with the number of columns being the number of classes and column names being the class labels; the first level of the \code{truth} factor must be the positive class). See examples. Set to \code{FALSE} (default) to use unmodified truth, response, and probability values from model output.
+#' @param ... Optional arguments to be passed to the \code{modify_trp} function (e.g., a classification threshold).
 #'
 #' @return 
 #' For \code{test = "bayes"} a list of \code{BEST} objects. In any other 
@@ -133,8 +135,94 @@
 #' cpi(task = mytask, learner = lrn("regr.ranger"), 
 #'     resampling = rsmp("holdout"), 
 #'     knockoff_fun = seqknockoff::knockoffs_seq)
-#' }   
+#'
+#' # Use a function to modify the truth, response, and probability model outputs
+#' # Add a probability data.frame to predictions when regression was run on a
+#' # 0/1 binary outcome (i.e., treat the response as a probability, make the
+#' # response a "classified" outcome)
 #' 
+#' # Data prep:
+#' data <- palmerpenguins::penguins
+#' data$species <- ifelse(data$species == "Adelie", 1, 0)
+#' data <- data[, c("species", "bill_length_mm", "bill_depth_mm", "flipper_length_mm", "body_mass_g")]
+#' data <- data[complete.cases(data), ]
+#' task <- TaskRegr$new(id = "penguins.regr", data, target = "species")
+
+#' response_is_prob <- function(truth, response, prob) {
+#'    prob <- setNames(data.frame(response, 1 - response), nm = c("1", "0"))
+#'    response <- ifelse(response >= 0.5, yes = 1, no = 0)
+#'    
+#'    return(list(truth = truth, response = response, prob = prob))
+#'   }     
+#' 
+#' cpi(task = task, 
+#'     learner = lrn("regr.ranger"), 
+#'      resampling = rsmp("holdout"), 
+#'      measure = "classif.logloss", test = "t", 
+#'      modify_trp = response_is_prob)
+#'      
+#' # Same as above, but also passing an additional argument to the
+#' # modify_trp function that makes a new classification threshold
+#' # Same data can be used.
+#'  
+#' response_is_prob_new_thresh <- function(truth, response, prob, classification_thresh) {
+#'     prob <- setNames(data.frame(response, 1 - response), nm = c("1", "0"))
+#'     response <- ifelse(response >= classification_thresh, yes = 1, no = 0)
+#'     
+#'     return(list(truth = truth, response = response, prob = prob))
+#' }
+#'    
+#' cpi(task = task, 
+#'     learner = lrn("regr.ranger"), 
+#'     resampling = rsmp("holdout"), 
+#'     measure = "classif.logloss", test = "t", 
+#'     modify_trp = response_is_prob_new_thresh,
+#'     classification_thresh = 0.3)
+#'        
+#' # Setting a new classification threshold on a "classif" learner and rescaling
+#' # probability outputs such that predictions lower than the new threshold
+#' # are on [0,0.5] and predictions above the new threshold are on [0.5, 1]
+#'  
+#' rescale_prob <- function(truth, response, prob, classification_thresh) {
+#'  
+#'     rescale <- function(x, old_max, old_min, new_max, new_min) {
+#'       return(((new_max - new_min) / (old_max - old_min)) * (x - old_max) + new_max)
+#'     }
+#' 
+#'    classes <- levels(truth)
+#'    response <- ifelse(prob[, classes[1]] >= classification_thresh, yes = classes[1], no = classes[2])
+#'    prob[, classes[1]] <- ifelse(prob[, classes[1]] <= classification_thresh,
+#'                                 yes = rescale(x = prob[, classes[1]],
+#'                                               old_max = classification_thresh,
+#'                                               old_min = 0,
+#'                                               new_max = 0.5,
+#'                                               new_min = 0),
+#'                                 no = rescale(x = prob[, classes[1]],
+#'                                              old_max = 1,
+#'                                              old_min = classification_thresh,
+#'                                              new_max = 1,
+#'                                              new_min = 0.5))
+#' 
+#'    prob[, classes[2]] <- 1 - prob[, classes[1]]
+#' 
+#'    return(list(truth = truth, response = response, prob = prob))
+#'  }
+#'  
+#'  # Data prep
+#'  data = palmerpenguins::penguins
+#'  data$species = factor(ifelse(data$species == "Adelie", "1", "0"))
+#'  data <- data[, c("species", "bill_length_mm", "bill_depth_mm", "flipper_length_mm", "body_mass_g")]
+#'  data <- data[complete.cases(data), ]
+
+#'  cpi(task = TaskClassif$new("penguins.binary", data, target = "species", positive = "1"), 
+#'      learner = lrn("classif.ranger", predict_type = "prob"), 
+#'      resampling = rsmp("holdout"), 
+#'      measure = "classif.logloss", test = "t", 
+#'      modify_trp = rescale_prob,
+#'      classification_thresh = 0.3)
+#'}
+
+
 cpi <- function(task, learner, 
                 resampling = NULL,
                 test_data = NULL,
@@ -146,7 +234,9 @@ cpi <- function(task, learner,
                 x_tilde = NULL,
                 knockoff_fun = function(x) knockoff::create.second_order(as.matrix(x)),
                 groups = NULL,
-                verbose = FALSE) {
+                verbose = FALSE,
+                modify_trp = FALSE,
+                ...) {
   
   # Set verbose level (and save old state)
   old_logger_treshold <- lgr::get_logger("mlr3")$threshold
@@ -220,7 +310,7 @@ cpi <- function(task, learner,
   fit_full <- fit_learner(learner = learner, task = task, resampling = resampling, 
                           measure = measure, test_data = test_data, verbose = verbose)
   pred_full <- predict_learner(fit_full, task, resampling = resampling, test_data = test_data)
-  err_full <- compute_loss(pred_full, measure)
+  err_full <- compute_loss(pred_full, measure, modify_trp, ...)
   
   # Generate knockoff data
   if (is.null(x_tilde)) {
@@ -265,7 +355,7 @@ cpi <- function(task, learner,
     
     # Predict with knockoff data
     pred_reduced <- predict_learner(fit_full, reduced_task, resampling = resampling, test_data = reduced_test_data)
-    err_reduced <- compute_loss(pred_reduced, measure)
+    err_reduced <- compute_loss(pred_reduced, measure, modify_trp, ...)
     if (log) {
       dif <- log(err_reduced / err_full)
     } else {

--- a/man/cpi.Rd
+++ b/man/cpi.Rd
@@ -17,7 +17,9 @@ cpi(
   x_tilde = NULL,
   knockoff_fun = function(x) knockoff::create.second_order(as.matrix(x)),
   groups = NULL,
-  verbose = FALSE
+  verbose = FALSE,
+  modify_trp = FALSE,
+  ...
 )
 }
 \arguments{
@@ -58,6 +60,21 @@ created with the function given in \code{knockoff_fun}.}
 groups, i.e. compute CPI for each feature. See examples.}
 
 \item{verbose}{Verbose output of resampling procedure.}
+
+\item{modify_trp}{An optional function to modify the \code{truth}, \code{response}, 
+and \code{prob} values of the model output. Function must take as arguments the 
+original \code{truth}, \code{response}, and \code{prob} output from model 
+predictions and return a named list of \code{truth}, \code{response}, and 
+\code{prob} values, some of which may be modified. For modified values to work 
+nicely with the rest of the package, they must match the expected format of 
+unmodified values (e.g., \code{prob} must be a data.frame with the number of columns
+being the number of classes and column names being the class labels; the first 
+level of the \code{truth} factor must be the positive class). See examples. Set to 
+\code{FALSE} (default) to use unmodified truth, response, and probability values 
+from model output.}
+
+\item{...}{Optional arguments to be passed to the \code{modify_trp} function 
+(e.g., a classification threshold).}
 }
 \value{
 For \code{test = "bayes"} a list of \code{BEST} objects. In any other 
@@ -154,8 +171,97 @@ mytask <- as_task_regr(iris, target = "Petal.Length")
 cpi(task = mytask, learner = lrn("regr.ranger"), 
     resampling = rsmp("holdout"), 
     knockoff_fun = seqknockoff::knockoffs_seq)
-}   
 
+# Use a function to modify the truth, response, and probability model outputs
+# Add a probability data.frame to predictions when regression was run on a
+# 0/1 binary outcome (i.e., treat the response as a probability, make the
+# response a "classified" outcome)
+
+# Data prep:
+data <- palmerpenguins::penguins
+data$species <- ifelse(data$species == "Adelie", 1, 0)
+keep_cols <- c("species", "bill_length_mm", "bill_depth_mm", 
+               "flipper_length_mm", "body_mass_g")
+data <- data[, keep_cols]
+data <- data[complete.cases(data), ]
+
+response_is_prob <- function(truth, response, prob) {
+   prob <- setNames(data.frame(response, 1 - response), nm = c("1", "0"))
+   response <- ifelse(response >= 0.5, yes = 1, no = 0)
+   
+   return(list(truth = truth, response = response, prob = prob))
+  }     
+
+cpi(task = TaskRegr$new(id = "penguins.regr", backend = data, target = "species"), 
+    learner = lrn("regr.ranger"), 
+     resampling = rsmp("holdout"), 
+     measure = "classif.logloss", test = "t", 
+     modify_trp = response_is_prob)
+     
+# Same as above, but also passing an additional argument to the
+# modify_trp function that makes a new classification threshold
+# Same data can be used.
+ 
+response_is_prob_new_thresh <- 
+  function(truth, response, prob, classification_thresh) {
+    prob <- setNames(data.frame(response, 1 - response), nm = c("1", "0"))
+    response <- ifelse(response >= classification_thresh, yes = 1, no = 0)
+    
+    return(list(truth = truth, response = response, prob = prob))
+  }
+   
+cpi(task = TaskRegr$new(id = "penguins.regr", backend = data, target = "species"), 
+    learner = lrn("regr.ranger"), 
+    resampling = rsmp("holdout"), 
+    measure = "classif.logloss", test = "t", 
+    modify_trp = response_is_prob_new_thresh,
+    classification_thresh = 0.3)
+       
+# Setting a new classification threshold on a "classif" learner and rescaling
+# probability outputs such that predictions lower than the new threshold
+# are on [0,0.5] and predictions above the new threshold are on [0.5, 1]
+ 
+rescale_prob <- function(truth, response, prob, classification_thresh) {
+ 
+    rescale <- function(x, old_max, old_min, new_max, new_min) {
+      return(((new_max - new_min) / (old_max - old_min)) * (x - old_max) + new_max)
+    }
+
+   classes <- levels(truth)
+   response <- ifelse(prob[, classes[1]] >= classification_thresh, 
+                      yes = classes[1], no = classes[2])
+   prob[, classes[1]] <- ifelse(prob[, classes[1]] <= classification_thresh,
+                                yes = rescale(x = prob[, classes[1]],
+                                              old_max = classification_thresh,
+                                              old_min = 0,
+                                              new_max = 0.5,
+                                              new_min = 0),
+                                no = rescale(x = prob[, classes[1]],
+                                             old_max = 1,
+                                             old_min = classification_thresh,
+                                             new_max = 1,
+                                             new_min = 0.5))
+
+   prob[, classes[2]] <- 1 - prob[, classes[1]]
+
+   return(list(truth = truth, response = response, prob = prob))
+ }
+ 
+ # Data prep
+ data = palmerpenguins::penguins
+ data$species = factor(ifelse(data$species == "Adelie", "1", "0"))
+ keep_cols <- c("species", "bill_length_mm", "bill_depth_mm", 
+                "flipper_length_mm", "body_mass_g")
+ data <- data[, keep_cols]
+ data <- data[complete.cases(data), ]
+ cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
+                            target = "species", positive = "1"), 
+     learner = lrn("classif.ranger", predict_type = "prob"), 
+     resampling = rsmp("holdout"), 
+     measure = "classif.logloss", test = "t", 
+     modify_trp = rescale_prob,
+     classification_thresh = 0.3)
+}
 }
 \references{
 Watson, D. & Wright, M. (2020). Testing conditional independence in 

--- a/man/cpi.Rd
+++ b/man/cpi.Rd
@@ -254,6 +254,7 @@ rescale_prob <- function(truth, response, prob, classification_thresh) {
                 "flipper_length_mm", "body_mass_g")
  data <- data[, keep_cols]
  data <- data[complete.cases(data), ]
+ 
  cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
                             target = "species", positive = "1"), 
      learner = lrn("classif.ranger", predict_type = "prob"), 
@@ -262,6 +263,7 @@ rescale_prob <- function(truth, response, prob, classification_thresh) {
      modify_trp = rescale_prob,
      classification_thresh = 0.3)
 }
+
 }
 \references{
 Watson, D. & Wright, M. (2020). Testing conditional independence in 


### PR DESCRIPTION
This PR addresses some of the need that arose in [https://github.com/bips-hb/cpi/issues/10](https://github.com/bips-hb/cpi/issues/10). In some use cases (not sure how common!), a user may need to modify the `truth`, `response`, or `prob` values output generated by the `predict_learner()` function. This patch introduces two new arguments to the `cpi()` function (which get passed to the `compute_loss()` function): `modify_trp` and `...`. 

`modify_trp` ("trp" stands for truth/response/prob) is by default `FALSE` (leave the `truth`/`response`/`prob` output alone) but can also take a user-defined function that accepts as arguments the original `truth`, `response`, and `prob` values (after the modification that takes place in the beginning of the `compute_loss()` function) as well as the `...` argument to allow for some flexibility. It must return a named list (names must be `truth`, `response`, and `prob`) with the updated values. If values don't need updating, a user can simply pass the original value to the corresponding list item in the returned object.

Some potential use cases (which I've added examples for in the docs):
1. A user wants to use a different classification threshold than 0.5 for choosing which level to classify a particular observation
2. A user is building a random forest regression on a 0/1 binary outcome in order to use an unbiased split selection criteria (e.g., the maxstat rule, which requires a regression approach not classification; further discussion [here](https://github.com/imbs-hl/ranger/issues/237)). That user then still wants to use classification-like loss measures and therefore needs to create a `prob` object from the `response` object, and to update the `response` object to represent the predicted class.
3. A user wants to rescale the probability output (as in  [https://github.com/bips-hb/cpi/issues/10](https://github.com/bips-hb/cpi/issues/10))

It strikes me that I can imagine the `modify_trp` and `...` arguments being passed to the `predict_learner()` function instead of `compute_loss()`, but the machinery at the start of `compute_loss()` makes the `truth`, `response`, and `prob` objects a little easier to work with (because they're made consistent regardless of whether `inherits(pred, "Prediction")` is TRUE or FALSE). But this block could also move to the end of `predict_learner()` to make the `pred` output consistent at this stage? 

```
if (inherits(pred, "Prediction")) {
    truth <- pred$truth
    response <- pred$response
    prob <- pred$prob
  } else {
    truth <- do.call(c, lapply(pred, function(x) x$truth))
    response <- do.call(c, lapply(pred, function(x) x$response))
    prob <- do.call(rbind, lapply(pred, function(x) x$prob))
  }
```

Just a thought on organization (keeping all the prediction modification within `predict_learner()` instead of spread across `predict_learner()` and `compute_loss()`) to discard if not useful!

I think this approach allows maximum flexibility for a user, but I'm also happy to contribute to further discussion on other ways to implement something like this (if it might be implemented at all).

All checks pass and I added some worked examples to the documentation.

Thanks again for the great package!