### PR TITLE
allow for custom loss function to be passed as `measure` argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: A general test for conditional independence in supervised learning
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.2
 URL: https://github.com/bips-hb/cpi,
     https://bips-hb.github.io/cpi/
 BugReports: https://github.com/bips-hb/cpi/issues

--- a/R/compute_loss.R
+++ b/R/compute_loss.R
@@ -11,7 +11,10 @@ compute_loss <- function(pred, measure) {
     prob <- do.call(rbind, lapply(pred, function(x) x$prob))
   }
   
-  if (measure$id == "regr.mse") {
+  if (is.function(measure)) {
+    # custom loss function passed to measure argument by user
+    loss <- measure(truth, response, prob)
+  } else if (measure$id == "regr.mse") {
     # Squared errors
     loss <- (truth - response)^2
   } else if (measure$id == "regr.mae") {

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -184,10 +184,10 @@
 #' analysis_data <- rsample::analysis(split)
 #' assessment_data <- rsample::assessment(split)
 #' 
-#'  cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
+#'  cpi(task = TaskClassif$new(id = "penguins.binary", backend = analysis_data, 
 #'                             target = "species", positive = "1"), 
 #'     learner = lrn("classif.ranger", predict_type = "prob"), 
-#'     test_data = test_data,
+#'     test_data = assessment_data,
 #'     measure = mcc, 
 #'     test = "fisher",
 #'     B = 1)

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -16,7 +16,10 @@
 #' @param test_data External validation data, use instead of resampling.
 #' @param measure Performance measure (loss). Per default, use MSE 
 #'    (\code{"regr.mse"}) for regression and logloss (\code{"classif.logloss"}) 
-#'    for classification. 
+#'    for classification. Alternatively, \code{"measure"} can be a user-defined
+#'    loss function that takes \code{truth}, \code{response}, and \code{prob} as
+#'    inputs and returns a vector representing the "loss" (which may be a 
+#'    one-element vector). See examples.
 #' @param test Statistical test to perform, one of \code{"t"} (t-test, default), 
 #'   \code{"wilcox"} (Wilcoxon signed-rank test), \code{"binom"} (binomial 
 #'   test), \code{"fisher"} (Fisher permutation test) or "bayes" 
@@ -133,6 +136,62 @@
 #' cpi(task = mytask, learner = lrn("regr.ranger"), 
 #'     resampling = rsmp("holdout"), 
 #'     knockoff_fun = seqknockoff::knockoffs_seq)
+#'
+#' # User-supplied custom loss function; here we use Matthew's correlation coefficient
+#' 
+#' # Note that MCC yields a batch-level measure of loss, rather than an
+#' # observation-level measure. Statistical tests currently implemented rely on
+#' # observation-level measures to act as "samples" from a broader population.
+#' # Thus, these tests are not appropriate for a batch-level measure because only
+#' # one value is produced regardless of resampling scheme. It is currently
+#' # recommended to use the `test_data` functionality and preserve the batch-level
+#' # loss measurements for each set of `test_data`, which can be set up ahead of
+#' # time by the user to mimic various resampling strategies (e.g., a separate 
+#' # `test_data` set for each fold and each iteration in a repeated_cv resampling
+#' # approach). A user may then apply their own statistical tests to these multiple
+#' # batch-level CPI measures to assess significance. In this case, a user may
+#' # wish to set the `test` argument to "fisher" and the `B` argument to 1 in order
+#' # to prevent errors associated with trying to perform a statistical test on
+#' # a single observation.
+#' 
+#' mcc <- function(truth, response, prob) {
+#' 
+#'    classes <- levels(truth)
+#'    pos_class <- classes[1]
+#'    neg_class <- classes[2]
+#' 
+#'    tp <- as.numeric(length(which(truth == pos_class & response == pos_class)))
+#'    fp <- as.numeric(length(which(truth == neg_class & response == pos_class)))
+#'    tn <- as.numeric(length(which(truth == neg_class & response == neg_class)))
+#'    fn <- as.numeric(length(which(truth == pos_class & response == neg_class)))
+#'    
+#'    mcc <- ((tp * tn) - (fn * fp)) / sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
+#'    
+#'    loss <- 1 - mcc
+#' } 
+#' 
+#' # Data prep
+#' 
+#' data = palmerpenguins::penguins
+#' data$species = factor(ifelse(data$species == "Adelie", "1", "0"))
+#' keep_cols <- c("species", "bill_length_mm", "bill_depth_mm", 
+#'                 "flipper_length_mm", "body_mass_g")
+#' data <- data[, keep_cols]
+#' data <- data[complete.cases(data), ]
+#' 
+#' # split data into analysis and test data
+#' split <- rsample::initial_split(data)
+#' analysis_data <- rsample::analysis(split)
+#' assessment_data <- rsample::assessment(split)
+#' 
+#'  cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
+#'                             target = "species", positive = "1"), 
+#'     learner = lrn("classif.ranger", predict_type = "prob"), 
+#'     test_data = test_data,
+#'     measure = mcc, 
+#'     test = "fisher",
+#'     B = 1)
+#'       
 #' }   
 #' 
 cpi <- function(task, learner, 
@@ -169,8 +228,10 @@ cpi <- function(task, learner,
     measure <- msr(measure)
   }
   
-  if (!(measure$id %in% c("regr.mse", "regr.mae", "classif.ce", "classif.logloss", "classif.bbrier"))) {
-    stop("Currently only implemented for 'regr.mse', 'regr.mae', 'classif.ce', 'classif.logloss' and 'classif.bbrier' measures.")
+  if (!is.function(measure)) {
+    if (!(measure$id %in% c("regr.mse", "regr.mae", "classif.ce", "classif.logloss", "classif.bbrier"))) {
+      stop("Currently only implemented for 'regr.mse', 'regr.mae', 'classif.ce', 'classif.logloss' and 'classif.bbrier' measures.")
+    }
   }
   if (!(test %in% c("t", "fisher", "bayes", "wilcox", "binom"))) {
     stop("Unknown test in 'test' argument.")
@@ -182,9 +243,11 @@ cpi <- function(task, learner,
     }
   }
   
-  if (task$task_type == "classif" & measure$id %in% c("classif.logloss", "classif.bbrier")) {
-    if (learner$predict_type != "prob") {
-      stop("The selected loss function requires probability support. Try predict_type = 'prob' when creating the learner.")
+  if (!is.function(measure)) {
+    if (task$task_type == "classif" & measure$id %in% c("classif.logloss", "classif.bbrier")) {
+      if (learner$predict_type != "prob") {
+        stop("The selected loss function requires probability support. Try predict_type = 'prob' when creating the learner.")
+      }
     }
   }
   
@@ -243,7 +306,7 @@ cpi <- function(task, learner,
   } else {
     stop("Argument 'x_tilde' must be a matrix, data.frame or NULL.")
   }
-
+  
   # For each feature, fit reduced model and return difference in error
   cpi_fun <- function(i) {
     if (is.null(test_data)) {
@@ -273,7 +336,7 @@ cpi <- function(task, learner,
     }
     cpi <- mean(dif)
     se <- sd(dif) / sqrt(length(dif))
-
+    
     if (is.null(groups)) {
       res <- data.frame(Variable = task$feature_names[i],
                         CPI = unname(cpi), 

--- a/man/cpi.Rd
+++ b/man/cpi.Rd
@@ -205,10 +205,10 @@ split <- rsample::initial_split(data)
 analysis_data <- rsample::analysis(split)
 assessment_data <- rsample::assessment(split)
 
- cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
+ cpi(task = TaskClassif$new(id = "penguins.binary", backend = analysis_data, 
                             target = "species", positive = "1"), 
     learner = lrn("classif.ranger", predict_type = "prob"), 
-    test_data = test_data,
+    test_data = assessment_data,
     measure = mcc, 
     test = "fisher",
     B = 1)

--- a/man/cpi.Rd
+++ b/man/cpi.Rd
@@ -34,7 +34,10 @@ learner will be created via \code{mlr3::\link{lrn}}.}
 
 \item{measure}{Performance measure (loss). Per default, use MSE 
 (\code{"regr.mse"}) for regression and logloss (\code{"classif.logloss"}) 
-for classification.}
+for classification. Alternatively, \code{"measure"} can be a user-defined
+loss function that takes \code{truth}, \code{response}, and \code{prob} as
+inputs and returns a vector representing the "loss" (which may be a 
+one-element vector). See examples.}
 
 \item{test}{Statistical test to perform, one of \code{"t"} (t-test, default), 
 \code{"wilcox"} (Wilcoxon signed-rank test), \code{"binom"} (binomial 
@@ -154,6 +157,62 @@ mytask <- as_task_regr(iris, target = "Petal.Length")
 cpi(task = mytask, learner = lrn("regr.ranger"), 
     resampling = rsmp("holdout"), 
     knockoff_fun = seqknockoff::knockoffs_seq)
+
+# User-supplied custom loss function; here we use Matthew's correlation coefficient
+
+# Note that MCC yields a batch-level measure of loss, rather than an
+# observation-level measure. Statistical tests currently implemented rely on
+# observation-level measures to act as "samples" from a broader population.
+# Thus, these tests are not appropriate for a batch-level measure because only
+# one value is produced regardless of resampling scheme. It is currently
+# recommended to use the `test_data` functionality and preserve the batch-level
+# loss measurements for each set of `test_data`, which can be set up ahead of
+# time by the user to mimic various resampling strategies (e.g., a separate 
+# `test_data` set for each fold and each iteration in a repeated_cv resampling
+# approach). A user may then apply their own statistical tests to these multiple
+# batch-level CPI measures to assess significance. In this case, a user may
+# wish to set the `test` argument to "fisher" and the `B` argument to 1 in order
+# to prevent errors associated with trying to perform a statistical test on
+# a single observation.
+
+mcc <- function(truth, response, prob) {
+
+   classes <- levels(truth)
+   pos_class <- classes[1]
+   neg_class <- classes[2]
+
+   tp <- as.numeric(length(which(truth == pos_class & response == pos_class)))
+   fp <- as.numeric(length(which(truth == neg_class & response == pos_class)))
+   tn <- as.numeric(length(which(truth == neg_class & response == neg_class)))
+   fn <- as.numeric(length(which(truth == pos_class & response == neg_class)))
+   
+   mcc <- ((tp * tn) - (fn * fp)) / sqrt((tp + fp) * (tp + fn) * (tn + fp) * (tn + fn))
+   
+   loss <- 1 - mcc
+} 
+
+# Data prep
+
+data = palmerpenguins::penguins
+data$species = factor(ifelse(data$species == "Adelie", "1", "0"))
+keep_cols <- c("species", "bill_length_mm", "bill_depth_mm", 
+                "flipper_length_mm", "body_mass_g")
+data <- data[, keep_cols]
+data <- data[complete.cases(data), ]
+
+# split data into analysis and test data
+split <- rsample::initial_split(data)
+analysis_data <- rsample::analysis(split)
+assessment_data <- rsample::assessment(split)
+
+ cpi(task = TaskClassif$new(id = "penguins.binary", backend = data, 
+                            target = "species", positive = "1"), 
+    learner = lrn("classif.ranger", predict_type = "prob"), 
+    test_data = test_data,
+    measure = mcc, 
+    test = "fisher",
+    B = 1)
+      
 }   
 
 }


### PR DESCRIPTION
Allows for a custom loss function to be supplied to the measure argument. Must take truth, response, and prob as arguments (as they are output from the `predict_learner()` function followed by the few modifications at the beginning of the `compute_loss()` function (which themselves might be further modified by a call to the `modify_trp()` function). Returns a single vector (which may be a one-element vector) representing the loss (i.e., 1 - model skill measure).

Addresses some of the need described in https://github.com/bips-hb/cpi/issues/10.

I added an example to the help file that shows an implementation of Matthew's correlation coefficient. I included a note in that example about MCC being a batch-level skill measure and so that statistical approach currently implemented in this package isn't yet set up to handle that. The work around is to have the user set up a series of `test_data` data frames ahead of time, which may mimic a resampling strategy (like repeated cross-validation, with some number of iterations and folds defined), then to use that series of batch-level CPI values to conduct an external significance test.

All build tests and checks pass. DESCRIPTION and cpi.Rd files changed using {roxygen2}.