### PR TITLE
Allow lists of knockoff matrices to improve stability

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: cpi
 Type: Package
 Title: Conditional Predictive Impact
-Version: 0.1.4
-Date: 2022-03-02
+Version: 0.1.5
+Date: 2024-02-20
 Authors@R: 
     c(person(given = "Marvin N.",
              family = "Wright",
@@ -22,7 +22,7 @@ Description: A general test for conditional independence in supervised learning
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 URL: https://github.com/bips-hb/cpi,
     https://bips-hb.github.io/cpi/
 BugReports: https://github.com/bips-hb/cpi/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: A general test for conditional independence in supervised learning
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.0
+RoxygenNote: 7.3.2
 URL: https://github.com/bips-hb/cpi,
     https://bips-hb.github.io/cpi/
 BugReports: https://github.com/bips-hb/cpi/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 
+# cpi 0.1.5
+* Allow a list of knockoff matrices to improve stability
+
 # cpi 0.1.4
 * Reset options() in vignette
 

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -28,6 +28,7 @@
 #' @param x_tilde Knockoff matrix or data.frame. If not given (the default), it will be 
 #'   created with the function given in \code{knockoff_fun}. 
 #'   Also accepts a list of matrices or data.frames.
+#' @param aggr_fun Aggregation function over replicates. 
 #' @param knockoff_fun Function to generate knockoffs. Default: 
 #'   \code{knockoff::\link{create.second_order}} with matrix argument.
 #' @param groups (Named) list with groups. Set to \code{NULL} (default) for no
@@ -145,6 +146,7 @@ cpi <- function(task, learner,
                 B = 1999,
                 alpha = 0.05, 
                 x_tilde = NULL,
+                aggr_fun = mean,
                 knockoff_fun = function(x) knockoff::create.second_order(as.matrix(x)),
                 groups = NULL,
                 verbose = FALSE) {
@@ -289,7 +291,7 @@ cpi <- function(task, learner,
     })
     
     # Average over results with different knockoffs
-    err_reduced <- rowMeans(err_reduced)
+    err_reduced <- apply(err_reduced, 1, aggr_fun)
     
     if (log) {
       dif <- log(err_reduced / err_full)

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -26,7 +26,8 @@
 #' @param B Number of permutations for Fisher permutation test.
 #' @param alpha Significance level for confidence intervals.
 #' @param x_tilde Knockoff matrix or data.frame. If not given (the default), it will be 
-#'   created with the function given in \code{knockoff_fun}.
+#'   created with the function given in \code{knockoff_fun}. 
+#'   Also accepts a list of matrices or data.frames.
 #' @param knockoff_fun Function to generate knockoffs. Default: 
 #'   \code{knockoff::\link{create.second_order}} with matrix argument.
 #' @param groups (Named) list with groups. Set to \code{NULL} (default) for no
@@ -227,8 +228,9 @@ cpi <- function(task, learner,
     if (is.null(test_data)) {
       x_tilde <- knockoff_fun(task$data(cols = task$feature_names))
     } else {
-      test_data_x_tilde <- knockoff_fun(test_data[, task$feature_names])
+      x_tilde <- knockoff_fun(test_data[, task$feature_names])
     }
+    x_tilde <- list(x_tilde)
   } else if (is.matrix(x_tilde) | is.data.frame(x_tilde)) {
     if (is.null(test_data)) {
       if (any(dim(x_tilde) != dim(task$data(cols = task$feature_names)))) {
@@ -238,7 +240,22 @@ cpi <- function(task, learner,
       if (any(dim(x_tilde) != dim(test_data[, task$feature_names]))) {
         stop("Size of 'x_tilde' must match dimensions of data.")
       }
-      test_data_x_tilde <- x_tilde
+    }
+    x_tilde <- list(x_tilde)
+  } else if (is.list(x_tilde)) {
+    if (length(x_tilde) < 1) {
+      stop("If 'x_tilde' is a list, it cannot be empty.")
+    }
+    if (is.null(test_data)) {
+      #FIXME: Check all dims
+      if (any(dim(x_tilde[[1]]) != dim(task$data(cols = task$feature_names)))) {
+        stop("Size of 'x_tilde' must match dimensions of data.")
+      }
+    } else {
+      #FIXME: Check all dims
+      if (any(dim(x_tilde[[1]]) != dim(test_data[, task$feature_names]))) {
+        stop("Size of 'x_tilde' must match dimensions of data.")
+      }
     }
   } else {
     stop("Argument 'x_tilde' must be a matrix, data.frame or NULL.")
@@ -246,26 +263,34 @@ cpi <- function(task, learner,
 
   # For each feature, fit reduced model and return difference in error
   cpi_fun <- function(i) {
-    if (is.null(test_data)) {
-      reduced_test_data <- NULL
-      reduced_data <- as.data.frame(task$data())
-      reduced_data[, task$feature_names[i]] <- x_tilde[, task$feature_names[i]]
-      if (task$task_type == "regr") {
-        reduced_task <- as_task_regr(reduced_data, target = task$target_names)
-      } else if (task$task_type == "classif") {
-        reduced_task <- as_task_classif(reduced_data, target = task$target_names)
+    err_reduced <- sapply(x_tilde, function(x_tilde_i) {
+      if (is.null(test_data)) {
+        reduced_test_data <- NULL
+        reduced_data <- as.data.frame(task$data())
+        reduced_data[, task$feature_names[i]] <- x_tilde_i[, task$feature_names[i]]
+        if (task$task_type == "regr") {
+          reduced_task <- as_task_regr(reduced_data, target = task$target_names)
+        } else if (task$task_type == "classif") {
+          reduced_task <- as_task_classif(reduced_data, target = task$target_names)
+        } else {
+          stop("Unknown task type.")
+        }
       } else {
-        stop("Unknown task type.")
+        reduced_task <- NULL
+        reduced_test_data <- test_data
+        reduced_test_data[, task$feature_names[i]] <- x_tilde_i[, task$feature_names[i]]
       }
-    } else {
-      reduced_task <- NULL
-      reduced_test_data <- test_data
-      reduced_test_data[, task$feature_names[i]] <- test_data_x_tilde[, task$feature_names[i]]
-    }
+      
+      # Predict with knockoff data
+      pred_reduced <- predict_learner(fit_full, reduced_task, resampling = resampling, test_data = reduced_test_data)
+      err_reduced <- compute_loss(pred_reduced, measure)
+      
+      err_reduced
+    })
     
-    # Predict with knockoff data
-    pred_reduced <- predict_learner(fit_full, reduced_task, resampling = resampling, test_data = reduced_test_data)
-    err_reduced <- compute_loss(pred_reduced, measure)
+    # Average over results with different knockoffs
+    err_reduced <- rowMeans(err_reduced)
+    
     if (log) {
       dif <- log(err_reduced / err_full)
     } else {

--- a/man/cpi.Rd
+++ b/man/cpi.Rd
@@ -15,6 +15,7 @@ cpi(
   B = 1999,
   alpha = 0.05,
   x_tilde = NULL,
+  aggr_fun = mean,
   knockoff_fun = function(x) knockoff::create.second_order(as.matrix(x)),
   groups = NULL,
   verbose = FALSE
@@ -49,7 +50,10 @@ test), \code{"fisher"} (Fisher permutation test) or "bayes"
 \item{alpha}{Significance level for confidence intervals.}
 
 \item{x_tilde}{Knockoff matrix or data.frame. If not given (the default), it will be 
-created with the function given in \code{knockoff_fun}.}
+created with the function given in \code{knockoff_fun}. 
+Also accepts a list of matrices or data.frames.}
+
+\item{aggr_fun}{Aggregation function over replicates.}
 
 \item{knockoff_fun}{Function to generate knockoffs. Default: 
 \code{knockoff::\link{create.second_order}} with matrix argument.}


### PR DESCRIPTION
Example: 

````R
library(mlr3verse)
library(cpi)

task <- tsk("mtcars")
ko <- replicate(5, knockoff::create.second_order(as.matrix(task$data()[, -1])), 
                simplify = FALSE)
cpi(task = tsk("mtcars"), learner = lrn("regr.lm"), 
    resampling = rsmp("holdout"), 
    x_tilde = ko)
````