### PR TITLE
Remove BEST dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: cpi
 Type: Package
 Title: Conditional Predictive Impact
-Version: 0.1.4
-Date: 2022-03-02
+Version: 0.1.5
+Date: 2024-11-05
 Authors@R: 
     c(person(given = "Marvin N.",
              family = "Wright",
@@ -28,7 +28,6 @@ URL: https://github.com/bips-hb/cpi,
 BugReports: https://github.com/bips-hb/cpi/issues
 Imports: foreach, mlr3, lgr, knockoff
 Suggests: 
-    BEST,
     mlr3learners,
     ranger,
     glmnet,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 
+# cpi 0.1.5
+* Remove BEST dependency (removed from CRAN)
+
 # cpi 0.1.4
 * Reset options() in vignette
 

--- a/R/cpi.R
+++ b/R/cpi.R
@@ -176,10 +176,12 @@ cpi <- function(task, learner,
     stop("Unknown test in 'test' argument.")
   }
   if (test == "bayes") {
-    if (!requireNamespace("BEST", quietly = TRUE)) {
-      stop("Package \"BEST\" needed for Bayesian testing. Please install it.",
-           call. = FALSE)
-    }
+    # if (!requireNamespace("BEST", quietly = TRUE)) {
+    #   stop("Package \"BEST\" needed for Bayesian testing. Please install it.",
+    #        call. = FALSE)
+    # }
+    stop("Bayesian testing currently not implemented as BEST package was removed from CRAN.",
+         call. = FALSE)
   }
   
   if (task$task_type == "classif" & measure$id %in% c("classif.logloss", "classif.bbrier")) {
@@ -309,8 +311,9 @@ cpi <- function(task, learner,
       res$p.value <- (sum(perm_means >= orig_mean) + 1)/(B + 1)
       res$ci.lo <- orig_mean - quantile(perm_means, 1 - alpha)
     } else if (test == "bayes") {
-      res <- list(BEST::BESTmcmc(dif, parallel = FALSE, verbose = FALSE))
-      names(res) <- task$feature_names[i]
+      #res <- list(BEST::BESTmcmc(dif, parallel = FALSE, verbose = FALSE))
+      #names(res) <- task$feature_names[i]
+      message("Bayesian testing currently not implemented as BEST package was removed from CRAN.")
     } else if (test %in% c('t', 'wilcox', 'binom')) {
       if (test == "t") {
         test_result <- t.test(dif, alternative = 'greater', 


### PR DESCRIPTION
BEST was removed from CRAN. Until we have an alternative, we remove Bayesian testing. :(