### PR TITLE
Allow for already-instantiated resampler to be passed to `cpi()` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: A general test for conditional independence in supervised learning
 License: GPL (>= 3)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.1
 URL: https://github.com/bips-hb/cpi,
     https://bips-hb.github.io/cpi/
 BugReports: https://github.com/bips-hb/cpi/issues

--- a/man/cpi.Rd
+++ b/man/cpi.Rd
@@ -28,7 +28,14 @@ learner will be created via \code{mlr3::\link{lrn}}.}
 
 \item{resampling}{Resampling strategy, \code{mlr3} resampling object 
 (e.g. \code{rsmp("holdout")}), "oob" (out-of-bag) or "none" 
-(in-sample loss).}
+(in-sample loss). Note if a \code{mlr3} resampling object is passed, it is
+sometimes helpful to instantiate it ahead of time particularly if 
+additional parameters are needed to do so (e.g., \code{rsmp("custom_cv")}
+requires an \code{f} or \code{col} specification, which has to happen
+during instantiation. This can be achieved by the user by doing this step
+outside of the \code{cpi()} function call, but relying on the \code{cpi()}
+function to do it will fail since only a simple call to \code{$instantiate}
+is done internally).}
 
 \item{test_data}{External validation data, use instead of resampling.}
 


### PR DESCRIPTION
The `cpi()` function allows for custom resamplers to be passed to it. As written, the function automatically instantiates that resampler with no additional arguments, regardless of whether it has already been instantiated. However, calling `$instantiate` can break with some resamplers since they might require additional parameters to be passed. This patch allows an already instantiated resampler to be passed to the cpi function instead. It uses the `is_instantiated` functionality to check if the resampler has already been instantiated. In that case, it does not try to instantiate. In other cases, the `cpi()` function will try what it has done before-- to instantiate the resampler with no arguments.

This arose when I was trying to use a "custom_cv" resampler (`rsmp("custom_cv")`) which requires an additional argument `f` to specify membership of each row in a factor level.